### PR TITLE
Upgrades httpoison & returns errors w/ http client

### DIFF
--- a/lib/mailchimp/account.ex
+++ b/lib/mailchimp/account.ex
@@ -18,13 +18,15 @@ defmodule Mailchimp.Account do
   end
 
   def get do
-    {:ok, response} = HTTPClient.get("/")
-    case response do
-      %Response{status_code: 200, body: body} ->
+    case HTTPClient.get("/") do
+      {:ok, %Response{status_code: 200, body: body}} ->
         {:ok, __MODULE__.new(body)}
 
-      %Response{status_code: _, body: body} ->
+      {:ok, %Response{status_code: _, body: body}} ->
         {:error, body}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule Mailchimp.Mixfile do
   end
 
   defp deps do
-    [{:httpoison, "~> 0.12"},
+    [{:httpoison, "~> 1.0"},
      {:poison, "~> 3.1"},
      {:mock, "~> 0.2.0", only: :test},
      {:ex_doc, ">= 0.0.0", only: :dev}]


### PR DESCRIPTION
I was having issues with timeout errors throwing exceptions, since this was only matching on `{:ok, response}`

This returns errors, so they can be matched in calling code.