### PR TITLE
feat: add get_list to directly fetch an Account List from an ID

### DIFF
--- a/lib/mailchimp/account.ex
+++ b/lib/mailchimp/account.ex
@@ -56,4 +56,24 @@ defmodule Mailchimp.Account do
     {:ok, lists} = lists(account, query_params)
     lists
   end
+
+  @doc """
+    Fetch a List from an ID
+  """
+  def get_list(%__MODULE__{links: %{"lists" => %Link{href: href}}}, list_id, query_params \\ %{}) do
+    {:ok, response} = HTTPClient.get(href <> "/#{list_id}", [], params: query_params)
+
+    case response do
+      %Response{status_code: 200, body: body} ->
+        {:ok, List.new(body)}
+
+      %Response{status_code: _, body: body} ->
+        {:error, body}
+    end
+  end
+
+  def get_list!(account, list_id, query_params \\ %{}) do
+    {:ok, list} = get_list(account, list_id, query_params)
+    list
+  end
 end


### PR DESCRIPTION
This implements the `GET /lists/{list_id}` documented here: https://mailchimp.com/developer/reference/lists/

It allows to retrieve a list from an ID:

```elixir
iex(116)> {:ok, list} = Mailchimp.Account.get_list(account, "f0ob4r")                                                                                                                       

{:ok,                                                                                                                                                                                           
 %Mailchimp.List{                                                                                                                                                                               
   beamer_address: "xxxxx@inbound.mailchimp.com",                                                                                                                          
   campaign_defaults: %{                                                                                                                                                                        
     from_email: "contact@foobar.com",                                                                                                                                                             
     from_name: "Foobar",                                                                                                                                                            
     language: "en",                                                                                                                                                                            
     subject: ""                                                                                                                                                                                
   },                                                                                                                                                                                           
   [...]
}
```                                                                                                                                                                 
                                                   

