### PR TITLE
feat: allow to use custom Mailchimp endpoint

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
 use Mix.Config
 
 config :mailchimp,
-  api_key: System.get_env("MAILCHIMP_TEST_API_KEY")
+  api_key: System.get_env("MAILCHIMP_TEST_API_KEY", "your apikey-us19")

--- a/lib/mailchimp/config.ex
+++ b/lib/mailchimp/config.ex
@@ -4,6 +4,7 @@ defmodule Mailchimp.Config do
   """
 
   @default_api_version "3.0"
+  @default_api_endpoint "api.mailchimp.com"
 
   @doc """
   Return configured API Key
@@ -36,6 +37,23 @@ defmodule Mailchimp.Config do
   def api_version, do: Application.get_env(:mailchimp, :api_version, @default_api_version)
 
   @doc """
+  Return configured API endpoint
+
+  ### Examples
+
+    iex> Application.put_env(:mailchimp, :api_endpoint, "api.mc.local")
+    iex> Mailchimp.Config.api_endpoint()
+    "api.mc.local"
+
+    iex> Application.delete_env(:mailchimp, :api_endpoint)
+    iex> Mailchimp.Config.api_endpoint()
+    "api.mailchimp.com"
+
+  """
+  @spec api_endpoint() :: String.t()
+  def api_endpoint, do: Application.get_env(:mailchimp, :api_endpoint, @default_api_endpoint)
+
+  @doc """
   Return configured API Version
 
   ### Examples
@@ -65,6 +83,6 @@ defmodule Mailchimp.Config do
   """
   @spec root_endpoint!() :: String.t() | no_return
   def root_endpoint! do
-    "https://#{shard!()}.api.mailchimp.com/#{api_version()}/"
+    "https://#{shard!()}.#{api_endpoint()}/#{api_version()}/"
   end
 end

--- a/lib/mailchimp/member.ex
+++ b/lib/mailchimp/member.ex
@@ -79,10 +79,10 @@ defmodule Mailchimp.Member do
     {:ok, response} = HTTPClient.post(href <> "/tags", Jason.encode!(attrs))
 
     case response do
-      %Response{status_code: 204, body: body} ->
+      %Response{status_code: 204, body: _body} ->
         {:ok, user}
 
-      %Response{status_code: code, body: body} ->
+      %Response{status_code: _code, body: body} ->
         {:error, body}
     end
   end
@@ -92,7 +92,7 @@ defmodule Mailchimp.Member do
     user
   end
 
-  def delete(user = %__MODULE__{links: %{"delete" => %Link{href: href}}}) do
+  def delete(%__MODULE__{links: %{"delete" => %Link{href: href}}}) do
     {:ok, %HTTPoison.Response{status_code: status_code}} = HTTPClient.delete(href)
 
     {:ok, status_code}


### PR DESCRIPTION
This PR allows to use custom Mailchimp endpoint. This is very useful in case of testing by mocking a local HTTP API