### PR TITLE
Batch subscribe

### DIFF
--- a/test/mailchimp/list_test.exs
+++ b/test/mailchimp/list_test.exs
@@ -38,6 +38,55 @@ defmodule Mailchimp.ListTest do
     end
   end
 
+  describe "batch_subscribe/3" do
+    test "subscribes members" do
+      use_cassette "members.create" do
+        account = Account.get!()
+        assert [list] = Account.lists!(account)
+
+        assert {:ok, members} =
+                 List.batch_subscribe(
+                   list,
+                   [
+                     %{
+                       email_address: "mailchimp1-test@elixir.com",
+                       merge_fields: %{LNAME: "Test"},
+                       language: "de"
+                     }
+                   ]
+                 )
+
+        assert %{
+                 new_members: [
+                   %Member{status: "subscribed", merge_fields: %{LNAME: "Test"}, language: "de"}
+                 ]
+               } = members
+      end
+    end
+
+    test "subscribes members!" do
+      use_cassette "members.create" do
+        account = Account.get!()
+        assert [list] = Account.lists!(account)
+
+        assert members =
+                 List.batch_subscribe!(
+                   list,
+                   [
+                     %{
+                       email_address: "mailchimp1-test@elixir.com",
+                       status: "subscribed",
+                       merge_fields: %{LNAME: "Test"},
+                       language: "de"
+                     }
+                   ]
+                 )
+
+        assert %{new_members: [%Member{}]} = members
+      end
+    end
+  end
+
   describe "create_members/5" do
     test "creates members" do
       use_cassette "members.create" do


### PR DESCRIPTION
Batch subscribe members to Mailchimp. This API provides more flexibility than #23, such as being able to specify a **different first/last name for each user** in `merge_fields`. It also returns the full response if someone wants to use `update_existing` and get back `updated_members`.

I left the create_members API intact, updating it to use batch_subscribe. Since they both can take 3 parameters, I had to use a different name.

Follow up to #23 by @bsidoruk