### PR TITLE
Build fix

### DIFF
--- a/.github/workflows/.elixir.yml
+++ b/.github/workflows/.elixir.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: "1.10.3" # Define the elixir version [required]
-          otp-version: "22.3" # Define the OTP version [required]
+          elixir-version: "1.11.0" # Define the elixir version [required]
+          otp-version: "23.2" # Define the OTP version [required]
           experimental-otp: true
       - name: Restore dependencies cache
         uses: actions/cache@v2

--- a/.github/workflows/.elixir.yml
+++ b/.github/workflows/.elixir.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: [1.11] # Define the elixir version [required]
-          otp-version: [23.2] # Define the OTP version [required]
+          elixir-version: "1.11.0" # Define the elixir version [required]
+          otp-version: "23.2" # Define the OTP version [required]
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/.elixir.yml
+++ b/.github/workflows/.elixir.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: "1.10.3" # Define the elixir version [required]
-          otp-version: "22.3" # Define the OTP version [required]
+          elixir-version: [1.11] # Define the elixir version [required]
+          otp-version: [23.2] # Define the OTP version [required]
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/.elixir.yml
+++ b/.github/workflows/.elixir.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           elixir-version: "1.11.0" # Define the elixir version [required]
           otp-version: "23.2" # Define the OTP version [required]
+          experimental-otp: true
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/.elixir.yml
+++ b/.github/workflows/.elixir.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Set up Elixir
         uses: actions/setup-elixir@v1
         with:
-          elixir-version: "1.11.0" # Define the elixir version [required]
-          otp-version: "23.2" # Define the OTP version [required]
+          elixir-version: "1.10.3" # Define the elixir version [required]
+          otp-version: "22.3" # Define the OTP version [required]
           experimental-otp: true
       - name: Restore dependencies cache
         uses: actions/cache@v2


### PR DESCRIPTION
increasing the versions with using the experimental-otp flag causes the openssl version used to be 1.1 instead of 1.0, which is found on the ubuntu 20.04 image that is currently being used. last ubuntu had 1.0 and so it used to work with the lower versions of elixir/otp.