### PR TITLE
Use Bearer rather than Basic.

### DIFF
--- a/lib/mailchimp/http_client.ex
+++ b/lib/mailchimp/http_client.ex
@@ -1,5 +1,5 @@
 defmodule Mailchimp.HTTPClient do
-  @moduledoc  false
+  @moduledoc false
 
   use HTTPoison.Base
 
@@ -57,6 +57,6 @@ defmodule Mailchimp.HTTPClient do
 
   """
   def process_request_headers(headers) do
-    [{"Authorization", "Basic #{Config.api_key!()}"} | headers]
+    [{"Authorization", "Bearer #{Config.api_key!()}"} | headers]
   end
 end


### PR DESCRIPTION
How is it going?

Thanks for this library, we recently integrated it on our project and, during `dev`, we had no issues.
However when going to `prod` we we're getting `api key not valid` and eventually, I realized that using `Bearer` rather than `Basic` on the authentication header, solved our issues.

[Mailchimp docs](https://mailchimp.com/developer/marketing/docs/fundamentals/#authenticate-with-an-api-key-or-oauth-2-token) also seem to indicate that we should use `Bearer`.

I can't explain why `Basic` worked on one case and not the other.

But anyways, here is a PR to use `Bearer`.
Please feel free to discard if you think it shouldn't be like so.


Cheers.